### PR TITLE
fix issues at run time

### DIFF
--- a/tpc-ds-2.4/openLookeng/openLookeng-benchmark.py
+++ b/tpc-ds-2.4/openLookeng/openLookeng-benchmark.py
@@ -139,7 +139,7 @@ def run_openlookeng_benchmark(query_dir, results_dir, num_runs):
             run_command("java -jar %s --server %s:%s --catalog %s --schema %s --file __tmp_current_query.sql"
                         "> %s/runs/%s.run 2>&1" % (cli, server, port, catalog, databaseName, results_dir, filename))
             # Get query runtime
-            output = run_command_with_output("%s --server %s:%s --catalog %s --schema %s --file "
+            output = run_command_with_output("java -jar %s --server %s:%s --catalog %s --schema %s --file "
                         "__tmp_get_runtime_from_openlookeng.sql" %
                         (cli, server, port, catalog, databaseName))
             query_id = get_query_id(output)

--- a/tpc-ds-2.4/openLookeng/tpcds_2_4_presto/q30.sql
+++ b/tpc-ds-2.4/openLookeng/tpcds_2_4_presto/q30.sql
@@ -11,7 +11,7 @@
  group by wr_returning_customer_sk,ca_state)
  select c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag
        ,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address
-       ,c_last_review_date,ctr_total_return
+       ,c_last_review_date_sk,ctr_total_return
  from customer_total_return ctr1, customer_address, customer
  where ctr1.ctr_total_return > (select avg(ctr_total_return)*1.2
  			  from customer_total_return ctr2
@@ -21,7 +21,7 @@
        and ctr1.ctr_customer_sk = c_customer_sk
  order by c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag
                   ,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address
-                  ,c_last_review_date,ctr_total_return
+                  ,c_last_review_date_sk,ctr_total_return
  limit 100
 
 ;

--- a/tpc-ds-2.4/openLookeng/tpcds_2_4_presto/q84.sql
+++ b/tpc-ds-2.4/openLookeng/tpcds_2_4_presto/q84.sql
@@ -1,7 +1,7 @@
 ---q84-v2.4---
 
  select c_customer_id as customer_id
-       ,concat(coalesce(c_last_name,''), ', ', coalesce(c_first_name,'')) as customername
+       ,concat(concat(coalesce(c_last_name,''), ', '), coalesce(c_first_name,'')) as customername
  from customer
      ,customer_address
      ,customer_demographics


### PR DESCRIPTION
benchmark script used the cli  file directly as an executable, but the cli is no an executable  -> run cli by java
q30 uses the wrong column name -> correct the name
q84 missing concat in select clause -> added concat 